### PR TITLE
feat: add type casting for submissions

### DIFF
--- a/src/Drupal/FormGeneratorDrupal.php
+++ b/src/Drupal/FormGeneratorDrupal.php
@@ -206,13 +206,11 @@ final class FormGeneratorDrupal extends TransformationBase implements FormGenera
    *
    * @param array $element
    *   The form element to alter.
-   * @param \Shaper\Util\Context $context
-   *   The context.
    *
    * @return array
    *   The modified form.
    */
-  private function addValidationRules(array $element, Context $context): array {
+  private function addValidationRules(array $element): array {
     $required_field_names = $element['#json_schema']->required ?? [];
     // Add the required fields.
     foreach (array_keys($element) as $key) {

--- a/src/Drupal/FormValidatorDrupal.php
+++ b/src/Drupal/FormValidatorDrupal.php
@@ -8,6 +8,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use JsonSchema\Validator;
 use SchemaForms\ArrayToStdClass;
+use SchemaForms\RecursiveTypeCaster;
 
 /**
  * Generates Drupal Form API forms from JSON-Schema documents.
@@ -88,6 +89,22 @@ final class FormValidatorDrupal {
       return NULL;
     }
     return $message;
+  }
+
+  /**
+   * Casts form submissions to their corresponding JSON types.
+   *
+   * @param array $element
+   *   The form element.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   * @param object $schema
+   *   The data schema.
+   */
+  public static function typeCastRecursive(array $element, FormStateInterface $form_state, object $schema): void {
+    $data = $form_state->getValue($element['#parents']);
+    $data = RecursiveTypeCaster::recursiveTypeRefinements($data, $schema);
+    $form_state->setValueForElement($element, $data);
   }
 
 }

--- a/src/RecursiveTypeCaster.php
+++ b/src/RecursiveTypeCaster.php
@@ -2,6 +2,9 @@
 
 namespace SchemaForms;
 
+/**
+ * Casts a data structure to its JSON-Schema the best it can.
+ */
 final class RecursiveTypeCaster {
 
   /**

--- a/src/RecursiveTypeCaster.php
+++ b/src/RecursiveTypeCaster.php
@@ -40,13 +40,13 @@ final class RecursiveTypeCaster {
     $types = $schema->type;
     $types = is_array($types) ? $types : [$types];
     array_reduce([
-      'tryCastingNumber',
-      'tryCastingBoolean',
-      'tryCastingNull',
-      'tryCastingString',
+      static fn(&$d, $t) => static::tryCastingNumber($d, $t),
+      static fn(&$d, $t) => static::tryCastingBoolean($d, $t),
+      static fn(&$d, $t) => static::tryCastingNull($d, $t),
+      static fn(&$d, $t) => static::tryCastingString($d, $t),
     ],
       static function (bool $casted, string $method) use (&$data, $types) {
-        return $casted ?: static::$method($data, $types);
+        return $casted ?: $method($data, $types);
       },
       FALSE
     );

--- a/src/RecursiveTypeCaster.php
+++ b/src/RecursiveTypeCaster.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace SchemaForms;
+
+final class RecursiveTypeCaster {
+
+  /**
+   * Takes a data structure and tries its best to fit the types in the schema.
+   *
+   * @param mixed $data
+   *   The data.
+   * @param object $schema
+   *   The schema.
+   *
+   * @return mixed
+   *   The same data with refined types.
+   */
+  public static function recursiveTypeRefinements(mixed $data, object $schema): mixed {
+    if ($schema->type === 'object') {
+      // If the data is NOT an array or object, then do not do any type casting.
+      if (!is_array($data) && !is_object($data)) {
+        return $data;
+      }
+      // Handle each property recursively.
+      foreach ((array) $data as $key => $value) {
+        $data[$key] = static::recursiveTypeRefinements($value, $schema->properties->{$key});
+      }
+      return $data;
+    }
+    if ($schema->type === 'array') {
+      // If the data is NOT an array, then do not do any type casting.
+      if (!is_array($data)) {
+        return $data;
+      }
+      return array_map(static fn(mixed $item) => static::recursiveTypeRefinements($item, $schema->items), $data);
+    }
+    $types = $schema->type;
+    $types = is_array($types) ? $types : [$types];
+    array_reduce([
+      'tryCastingNumber',
+      'tryCastingBoolean',
+      'tryCastingNull',
+      'tryCastingString',
+    ],
+      static function (bool $casted, string $method) use (&$data, $types) {
+        return $casted ?: static::$method($data, $types);
+      },
+      FALSE
+    );
+    return $data;
+  }
+
+  /**
+   * Attempts to cast the data to a string.
+   *
+   * @param mixed $input
+   *   The input data. Passed by reference to change its type.
+   * @param array $types
+   *   The possible types.
+   *
+   * @return bool
+   *   TRUE if casting was possible. FALSE otherwise.
+   */
+  private static function tryCastingString(mixed &$input, array $types): bool {
+    if (in_array('string', $types)) {
+      $input = (string) $input;
+      return TRUE;
+    }
+    return $input;
+  }
+
+  /**
+   * Attempts to cast the data to NULL.
+   *
+   * @param mixed $input
+   *   The input data. Passed by reference to change its type.
+   * @param array $types
+   *   The possible types.
+   *
+   * @return bool
+   *   TRUE if casting was possible. FALSE otherwise.
+   */
+  private static function tryCastingNull(mixed &$input, array $types): bool {
+    if (in_array('null', $types) && empty($input)) {
+      $input = NULL;
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  /**
+   * Attempts to cast the data to a boolean.
+   *
+   * @param mixed $input
+   *   The input data. Passed by reference to change its type.
+   * @param array $types
+   *   The possible types.
+   *
+   * @return bool
+   *   TRUE if casting was possible. FALSE otherwise.
+   */
+  private static function tryCastingBoolean(mixed &$input, array $types): bool {
+    if (in_array('boolean', $types) && ($input == '0' || $input == '1')) {
+      $input = (boolean) $input;
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  /**
+   * Attempts to cast the data to a number.
+   *
+   * @param mixed $input
+   *   The input data. Passed by reference to change its type.
+   * @param array $types
+   *   The possible types.
+   *
+   * @return bool
+   *   TRUE if casting was possible. FALSE otherwise.
+   */
+  private static function tryCastingNumber(mixed &$input, array $types): bool {
+    if (!in_array('integer', $types) && !in_array('number', $types)) {
+      return FALSE;
+    }
+    if (intval($input) == $input) {
+      $input = intval($input);
+      return TRUE;
+    }
+    if (floatval($input) == $input) {
+      $input = floatval($input);
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+}

--- a/src/RecursiveTypeCaster.php
+++ b/src/RecursiveTypeCaster.php
@@ -40,10 +40,10 @@ final class RecursiveTypeCaster {
     $types = $schema->type;
     $types = is_array($types) ? $types : [$types];
     array_reduce([
-      static fn(&$d, $t) => static::tryCastingNumber($d, $t),
-      static fn(&$d, $t) => static::tryCastingBoolean($d, $t),
-      static fn(&$d, $t) => static::tryCastingNull($d, $t),
-      static fn(&$d, $t) => static::tryCastingString($d, $t),
+      static fn(&$data, $types) => static::tryCastingNumber($data, $types),
+      static fn(&$data, $types) => static::tryCastingBoolean($data, $types),
+      static fn(&$data, $types) => static::tryCastingNull($data, $types),
+      static fn(&$data, $types) => static::tryCastingString($data, $types),
     ],
       static function (bool $casted, string $method) use (&$data, $types) {
         return $casted ?: $method($data, $types);

--- a/tests/src/Drupal/SchemaForms/FormGeneratorDrupalTest.php
+++ b/tests/src/Drupal/SchemaForms/FormGeneratorDrupalTest.php
@@ -44,6 +44,7 @@ class FormGeneratorDrupalTest extends TestCase {
   public function testFormGeneration(string $schema, array $expected_form) {
     $expected_form['#element_validate'] = [[$this->sut, 'validateWithSchema']];
     $data = json_decode($schema);
+    $expected_form['#json_schema'] = $data;
     $actual_form = $this->sut->transform($data);
     $this->assertEquals(
       $expected_form,
@@ -187,7 +188,8 @@ class FormGeneratorDrupalTest extends TestCase {
   public function testFormGenerationWithUi(string $schema, array $ui_schema, array $expected_form) {
     $expected_form['#element_validate'] = [[$this->sut, 'validateWithSchema']];
     $data = json_decode($schema);
-    $context = new Context($ui_schema);
+    $expected_form['#json_schema'] = $data;
+    $context = new Context(['ui_hints' => $ui_schema]);
     $actual_form = $this->sut->transform($data, $context);
     $this->assertEquals(
       $expected_form,


### PR DESCRIPTION
This will allow correct validation of forms containing number/boolean types.

BREAKING CHANGE: the UI hints should now be moved to a 'ui_hints' key in the $context, instead of added directly to the root. This aims to avoid mixing UI hints with other top-level context properties.