### PR TITLE
fix: make validation work again

### DIFF
--- a/src/Drupal/FormValidatorDrupal.php
+++ b/src/Drupal/FormValidatorDrupal.php
@@ -5,6 +5,7 @@ namespace SchemaForms\Drupal;
 use Drupal\Component\Utility\Html;
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use JsonSchema\Validator;
 use SchemaForms\ArrayToStdClass;
@@ -38,11 +39,13 @@ final class FormValidatorDrupal {
     // Validate the massaged data against the schema.
     $num_errors = $validator->validate($data, $schema);
     if ($num_errors) {
+      // Build the mappings of paths to form paths.
+      $mappings = static::buildMappingsElementPaths($element, $element['#array_parents']);
       $errors = $validator->getErrors();
       // Now check if we can find a specific form element to trigger the error.
       $generic_errors = array_filter(
         array_map(
-          static fn(array $error) => self::errorForProp($element, $form_state, $error),
+          static fn(array $error) => self::errorForProp($element, $form_state, $error, $mappings),
           $errors
         )
       );
@@ -72,16 +75,22 @@ final class FormValidatorDrupal {
    *   The form state.
    * @param array $error
    *   The error data from the JSON-Schema validation.
+   * @param array $mappings
+   *   Mappings to find the form element.
    *
    * @return string|null
    *   String if we could not find the particular prop this error is for. NULL
    *   if the error could be set.
    */
-  private static function errorForProp(array $element, FormStateInterface $form_state, array $error): ?string {
-    $message = $error['message'] . ' ' . $error['constraint'];
-    $error_parents = array_filter(explode('/', $error['pointer']));
+  private static function errorForProp(array $element, FormStateInterface $form_state, array $error, array $mappings): ?string {
+    $message = $error['message'] . ' [JSON Schema violation of "' . $error['constraint'] . '"]';
+    $form_error_parents = $mappings[$error['pointer'] ?? ''];
     $key_exists = FALSE;
-    $error_element = NestedArray::getValue($element, $error_parents, $key_exists);
+    $error_element = NestedArray::getValue(
+      $element,
+      $form_error_parents,
+      $key_exists
+    );
     if ($key_exists) {
       $form_state->setError(
         $error_element,
@@ -110,6 +119,49 @@ final class FormValidatorDrupal {
     $data = UserInputCleaner::cleanUserInput($data);
     $data = RecursiveTypeCaster::recursiveTypeRefinements($data, $schema);
     $form_state->setValueForElement($element, $data);
+  }
+
+  /**
+   * Maps the JSON pointer paths to form element parents.
+   *
+   * It returns ['root', 0, 'removable_element', 'foo', 2, 'removable_element']
+   * from '/root/0/foo/2'.
+   *
+   * @param array $element
+   *   The form element.
+   * @param array $root_parents
+   *   The parents of the JSON Schema form.
+   * @param array $_current_mappings
+   *   The current mappings. This is an internal variable used for tracking.
+   *
+   * @return array
+   *   The mappings of paths from the JSON Pointer to the form structure.
+   */
+  private static function buildMappingsElementPaths(array $element, array $root_parents, array $_current_mappings = []): array {
+    $parents = $element['#array_parents'] ?? [];
+    // Now drop some parents to make everything relative to `/`.
+    $parents = array_slice($parents, count($root_parents));
+    $json_pointer_parents = array_filter(
+      $parents,
+      static fn (string $parent) => $parent !== 'removable_element'
+    );
+    $json_pointer = '/' . implode('/', $json_pointer_parents);
+    $_current_mappings[$json_pointer] = $parents;
+    $keys = Element::children($element);
+    if (empty($keys)) {
+      return $_current_mappings;
+    }
+    foreach ($keys as $key) {
+      if (in_array($key, ['remove_one', 'add_more'], TRUE)) {
+        continue;
+      }
+      $_current_mappings = static::buildMappingsElementPaths(
+        $element[$key],
+        $root_parents,
+        $_current_mappings
+      );
+    }
+    return $_current_mappings;
   }
 
 }


### PR DESCRIPTION
This supports reporting errors in deeply nested form elements.

![image](https://user-images.githubusercontent.com/1140906/183607795-e5a6aa4d-f5a9-4f76-aad3-1d84e1bac1b7.png)
